### PR TITLE
chore: Patch esm loader

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [14.x]
     steps:
     - name: Checkout dapp
       uses: actions/checkout@v2

--- a/api/package.json
+++ b/api/package.json
@@ -21,13 +21,13 @@
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jsdoc": "^32.3.0",
     "eslint-plugin-prettier": "^3.3.1",
+    "esm": "agoric-labs/esm#Agoric-built",
     "prettier": "^2.2.1"
   },
   "dependencies": {
     "@agoric/ertp": "*",
     "@agoric/eventual-send": "*",
     "@agoric/zoe": "*",
-    "esm": "^3.2.5",
     "json5": "^2.2.0"
   },
   "eslintConfig": {

--- a/contract/package.json
+++ b/contract/package.json
@@ -14,26 +14,26 @@
   },
   "devDependencies": {
     "agoric": "*",
+    "ava": "^3.13.0",
     "eslint": "^7.23.0",
     "eslint-config-airbnb-base": "^14.2.1 ",
     "eslint-config-jessie": "^0.0.6",
     "eslint-config-prettier": "^8.1.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-prettier": "^3.3.1",
-    "prettier": "^2.2.1",
-    "ava": "^3.13.0"
+    "esm": "agoric-labs/esm#Agoric-built",
+    "prettier": "^2.2.1"
   },
   "dependencies": {
-    "@agoric/bundle-source": "*",
     "@agoric/assert": "*",
     "@agoric/babel-parser": "^7.6.4",
+    "@agoric/bundle-source": "*",
     "@agoric/ertp": "*",
     "@agoric/eventual-send": "*",
     "@agoric/install-ses": "*",
     "@agoric/notifier": "*",
     "@agoric/store": "*",
-    "@agoric/zoe": "*",
-    "esm": "^3.2.5"
+    "@agoric/zoe": "*"
   },
   "ava": {
     "files": [

--- a/contract/src/contract.js
+++ b/contract/src/contract.js
@@ -12,7 +12,10 @@ import { E } from '@agoric/eventual-send';
  */
 const start = (zcf) => {
   // Create the internal baseball card mint
-  const { issuer, mint, brand } = makeIssuerKit('baseball cards', AssetKind.SET);
+  const { issuer, mint, brand } = makeIssuerKit(
+    'baseball cards',
+    AssetKind.SET,
+  );
 
   const zoeService = zcf.getZoeService();
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
     "build": "yarn workspaces run build"
   },
   "dependencies": {},
+  "resolutions": {
+    "**/esm": "agoric-labs/esm#Agoric-built"
+  },
   "prettier": {
     "trailingComma": "all",
     "singleQuote": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5640,10 +5640,9 @@ eslint@^7.11.0, eslint@^7.23.0:
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
-esm@^3.2.25, esm@^3.2.5:
+esm@^3.2.25, esm@^3.2.5, esm@agoric-labs/esm#Agoric-built:
   version "3.2.25"
-  resolved "https://registry.yarnpkg.com/esm/-/esm-3.2.25.tgz#342c18c29d56157688ba5ce31f8431fbb795cc10"
-  integrity sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==
+  resolved "https://codeload.github.com/agoric-labs/esm/tar.gz/3603726ad4636b2f865f463188fcaade6375638e"
 
 espree@^7.3.0, espree@^7.3.1:
   version "7.3.1"


### PR DESCRIPTION
This allows dependencies to migrate away from ESM. 
