### PR TITLE
chore: Revert individual ESM dependency pins

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -21,7 +21,7 @@
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jsdoc": "^32.3.0",
     "eslint-plugin-prettier": "^3.3.1",
-    "esm": "agoric-labs/esm#Agoric-built",
+    "esm": "^3.2.5",
     "prettier": "^2.2.1"
   },
   "dependencies": {

--- a/contract/package.json
+++ b/contract/package.json
@@ -21,7 +21,7 @@
     "eslint-config-prettier": "^8.1.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-prettier": "^3.3.1",
-    "esm": "agoric-labs/esm#Agoric-built",
+    "esm": "^3.2.5",
     "prettier": "^2.2.1"
   },
   "dependencies": {


### PR DESCRIPTION
This change removes the redundant pins on the ESM patch. The override for the workspace is sufficient.
