### PR TITLE
fix: Add language hint for Endo archive generator

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.1.0",
   "description": "Agoric Dapp web server handler",
+  "parsers": {
+    "js": "mjs"
+  },
   "scripts": {
     "build": "exit 0",
     "test": "exit 0",

--- a/contract/package.json
+++ b/contract/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "description": "Contract for the Agoric Dapp",
+  "parsers": {
+    "js": "mjs"
+  },
   "scripts": {
     "build": "exit 0",
     "test": "ava --verbose",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "_agstate/agoric-servers",
     "ui"
   ],
+  "parsers": {
+    "js": "mjs"
+  },
   "devDependencies": {
     "eslint": "^7.23.0",
     "eslint-config-airbnb": "^18.2.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -5,6 +5,9 @@
   "author": "Agoric",
   "license": "Apache-2.0",
   "homepage": ".",
+  "parsers": {
+    "js": "mjs"
+  },
   "scripts": {
     "build": "yarn build:ses; yarn build:react",
     "build:ses": "cp ../node_modules/ses/dist/lockdown.umd.js public/",


### PR DESCRIPTION
This adds a parsers declaration to package.json, which Endo's compartment mapper recognizes that a `.js` file is a JavaScript module and not a CommonJS module, but unlike `"type": "module"`, does not confuse `node -r esm`.

Search for “parsers” on https://github.com/Agoric/agoric-sdk/issues/2684 for rationale.