### PR TITLE
refactor: Convert RESM to NESM

### DIFF
--- a/api/deploy.js
+++ b/api/deploy.js
@@ -5,12 +5,12 @@
 
 import fs from 'fs';
 import { E } from '@agoric/eventual-send';
-import '@agoric/zoe/exported';
+import '@agoric/zoe/exported.js';
 import { amountMath } from '@agoric/ertp';
 
-import installationConstants from '../ui/src/conf/installationConstants';
+import installationConstants from '../ui/src/conf/installationConstants.js';
 
-import { cards } from './cards';
+import { cards } from './cards.js';
 
 // deploy.js runs in an ephemeral Node.js outside of swingset. The
 // spawner runs within ag-solo, so is persistent.  Once the deploy.js

--- a/api/package.json
+++ b/api/package.json
@@ -3,9 +3,7 @@
   "private": true,
   "version": "0.1.0",
   "description": "Agoric Dapp web server handler",
-  "parsers": {
-    "js": "mjs"
-  },
+  "type": "module",
   "scripts": {
     "build": "exit 0",
     "test": "exit 0",
@@ -26,7 +24,6 @@
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jsdoc": "^32.3.0",
     "eslint-plugin-prettier": "^3.3.1",
-    "esm": "^3.2.5",
     "prettier": "^2.2.1"
   },
   "dependencies": {

--- a/contract/deploy.js
+++ b/contract/deploy.js
@@ -1,10 +1,9 @@
 // @ts-check
 
-/* global require */
-
 import fs from 'fs';
-import '@agoric/zoe/exported';
+import '@agoric/zoe/exported.js';
 import { E } from '@agoric/eventual-send';
+import { resolve as importMetaResolve } from 'import-meta-resolve';
 
 // This script takes our contract code, installs it on Zoe, and makes
 // the installation publicly available. Our backend API script will
@@ -64,9 +63,12 @@ export default async function deployContract(
 
   // We also need to bundle and install the sellItems contract, which
   // is provided by Zoe. We don't need to write it ourselves.
-  const sellItemsBundle = await bundleSource(
-    require.resolve('@agoric/zoe/src/contracts/sellItems'),
+  const bundleUrl = await importMetaResolve(
+    '@agoric/zoe/src/contracts/sellItems.js',
+    import.meta.url,
   );
+  const bundlePath = new URL(bundleUrl).pathname;
+  const sellItemsBundle = await bundleSource(bundlePath);
   const sellItemsInstallation = await E(zoe).install(sellItemsBundle);
 
   // Let's share this installation with other people, so that

--- a/contract/package.json
+++ b/contract/package.json
@@ -3,9 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "description": "Contract for the Agoric Dapp",
-  "parsers": {
-    "js": "mjs"
-  },
+  "type": "module",
   "scripts": {
     "build": "exit 0",
     "test": "ava --verbose",
@@ -24,7 +22,6 @@
     "eslint-config-prettier": "^8.1.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-prettier": "^3.3.1",
-    "esm": "^3.2.5",
     "prettier": "^2.2.1"
   },
   "dependencies": {
@@ -36,14 +33,12 @@
     "@agoric/install-ses": "*",
     "@agoric/notifier": "*",
     "@agoric/store": "*",
-    "@agoric/zoe": "*"
+    "@agoric/zoe": "*",
+    "import-meta-resolve": "^1.1.1"
   },
   "ava": {
     "files": [
       "test/**/test-*.js"
-    ],
-    "require": [
-      "esm"
     ],
     "timeout": "10m"
   },

--- a/contract/test/test-contract.js
+++ b/contract/test/test-contract.js
@@ -1,7 +1,6 @@
-/* global __dirname require */
-
 // @ts-check
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+import { resolve as importMetaResolve } from 'import-meta-resolve';
 
 import bundleSource from '@agoric/bundle-source';
 
@@ -10,7 +9,7 @@ import { makeFakeVatAdmin } from '@agoric/zoe/tools/fakeVatAdmin.js';
 import { makeZoeKit } from '@agoric/zoe';
 import { makeIssuerKit, AmountMath } from '@agoric/ertp';
 
-const contractPath = `${__dirname}/../src/contract.js`;
+const contractPath = new URL('../src/contract.js', import.meta.url).pathname;
 
 test('zoe - sell baseball cards', async (t) => {
   const { zoeService } = makeZoeKit(makeFakeVatAdmin().admin);
@@ -32,9 +31,12 @@ test('zoe - sell baseball cards', async (t) => {
   } = makeIssuerKit('moola');
 
   // We will also install the sellItems contract from agoric-sdk
-  const sellItemsBundle = await bundleSource(
-    require.resolve('@agoric/zoe/src/contracts/sellItems'),
+  const bundleUrl = await importMetaResolve(
+    '@agoric/zoe/src/contracts/sellItems.js',
+    import.meta.url,
   );
+  const bundlePath = new URL(bundleUrl).pathname;
+  const sellItemsBundle = await bundleSource(bundlePath);
   const sellItemsInstallation = await E(zoe).install(sellItemsBundle);
 
   const { creatorFacet: baseballCardSellerFacet } = await E(zoe).startInstance(

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "eslint-plugin-prettier": "^3.3.1",
     "eslint-plugin-react": "^7.23.1",
     "eslint-plugin-react-hooks": "^4.2.0",
+    "import-meta-resolve": "^1.1.1",
     "prettier": "^2.2.1"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "js": "mjs"
   },
   "devDependencies": {
+    "@endo/eslint-plugin": "^0.3.10",
+    "@jessie.js/eslint-plugin": "^0.1.3",
     "eslint": "^7.23.0",
     "eslint-config-airbnb": "^18.2.1",
     "eslint-config-airbnb-base": "^14.2.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -5,14 +5,12 @@
   "author": "Agoric",
   "license": "Apache-2.0",
   "homepage": ".",
-  "parsers": {
-    "js": "mjs"
-  },
+  "type": "module",
   "scripts": {
     "build": "yarn build:ses; yarn build:react",
     "build:ses": "cp ../node_modules/ses/dist/lockdown.umd.js public/",
     "build:react": "react-scripts build; yarn build:post-patch",
-    "build:post-patch": "node -r esm ./ses-patch.js build/index.html",
+    "build:post-patch": "node ./ses-patch.js build/index.html",
     "lint-check": "eslint '**/*.{js,jsx}'",
     "lint-fix": "eslint --fix '**/*.{js,jsx}'",
     "start": "react-scripts start",

--- a/ui/public/.gitignore
+++ b/ui/public/.gitignore
@@ -1,0 +1,1 @@
+lockdown.umd.js

--- a/ui/ses-patch.js
+++ b/ui/ses-patch.js
@@ -1,5 +1,8 @@
-/* global process, require, module */
+/* global process */
 // @ts-check
+
+import fsPowers from 'fs';
+
 const pagePatch = {
   target: '<link name="unprocessed-script" content="lockdown.umd.js"/>',
   replacement: `
@@ -55,9 +58,9 @@ async function main(args, { readFile, writeFile }) {
   }
 }
 
-if (require.main === module) {
-  // eslint-disable-next-line global-require
-  main(process.argv.slice(2), require('fs').promises).catch((err) =>
-    console.error(err),
-  );
+if (new URL(import.meta.url).pathname === process.argv[1]) {
+  main(process.argv.slice(2), fsPowers.promises).catch((err) => {
+    console.error(err);
+    process.exitCode = -1;
+  });
 }

--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -6,7 +6,7 @@ import {
   activateWebSocket,
   deactivateWebSocket,
   getActiveSocket,
-} from './utils/fetch-websocket';
+} from './utils/fetch-websocket.js';
 
 import './App.css';
 
@@ -16,9 +16,9 @@ import ApproveOfferSnackbar from './components/ApproveOfferSnackbar.jsx';
 import BoughtCardSnackbar from './components/BoughtCardSnackbar.jsx';
 import EnableAppDialog from './components/EnableAppDialog.jsx';
 
-import { makeOfferForCards } from './makeOfferForCards';
+import { makeOfferForCards } from './makeOfferForCards.js';
 
-import dappConstants from './lib/constants';
+import dappConstants from './lib/constants.js';
 
 const {
   INSTANCE_BOARD_ID,

--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -1,8 +1,8 @@
-import './install-ses-lockdown';
+import './install-ses-lockdown.js';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
 import './index.css';
-import App from './App';
+import App from './App.js';
 
 ReactDOM.render(<App />, document.getElementById('root'));

--- a/ui/src/install-ses-lockdown.js
+++ b/ui/src/install-ses-lockdown.js
@@ -1,5 +1,5 @@
 import 'ses/lockdown';
-import '@agoric/eventual-send/shim';
+import '@agoric/eventual-send/shim.js';
 
 // eslint-disable-next-line no-undef
 lockdown({

--- a/ui/src/lib/api-client.js
+++ b/ui/src/lib/api-client.js
@@ -1,8 +1,8 @@
 // @ts-check
 
-import { registerSocket, closeSocket, getActiveSocket } from './socket';
+import { registerSocket, closeSocket, getActiveSocket } from './socket.js';
 
-import dappConstants from './constants';
+import dappConstants from './constants.js';
 
 const { API_URL } = dappConstants;
 

--- a/ui/src/lib/constants.js
+++ b/ui/src/lib/constants.js
@@ -1,5 +1,5 @@
 // Allow the runtime to override the defaults with __DAPP_CONSTANTS__
-import defaults from '../conf/defaults';
+import defaults from '../conf/defaults.js';
 
 // eslint-disable-next-line no-underscore-dangle, no-undef
 export default globalThis.__DAPP_CONSTANTS__ || defaults;

--- a/ui/src/lib/wallet-client.js
+++ b/ui/src/lib/wallet-client.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import { registerSocket, getActiveSocket, closeSocket } from './socket';
+import { registerSocket, getActiveSocket, closeSocket } from './socket.js';
 
 // Wallet bridge
 

--- a/ui/src/utils/constants.js
+++ b/ui/src/utils/constants.js
@@ -2,7 +2,7 @@
 
 /* global process */
 // Taken from window.DAPP_CONSTANTS_JSON in index.html, defaulting to .env.local.
-import defaults from '../conf/defaults';
+import defaults from '../conf/defaults.js';
 
 export default process.env.REACT_APP_DAPP_CONSTANTS_JSON
   ? JSON.parse(process.env.REACT_APP_DAPP_CONSTANTS_JSON)

--- a/ui/src/utils/fetch-websocket.js
+++ b/ui/src/utils/fetch-websocket.js
@@ -1,7 +1,7 @@
 /* eslint-disable */
 
 /* global process */
-import dappConstants from './constants';
+import dappConstants from './constants.js';
 
 const { API_URL, BRIDGE_URL, CONTRACT_NAME } = dappConstants;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3708,6 +3708,13 @@ builtin-status-codes@^3.0.0:
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
   integrity sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=
 
+builtins@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/builtins/-/builtins-4.0.0.tgz#a8345420de82068fdc4d6559d0456403a8fb1905"
+  integrity sha512-qC0E2Dxgou1IHhvJSLwGDSTvokbRovU5zZFuDY6oY8Y2lF3nGt5Ad8YZK7GMtqzY84Wu7pXTPeHQeHcXSXsRhw==
+  dependencies:
+    semver "^7.0.0"
+
 bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
@@ -6853,6 +6860,13 @@ import-local@^3.0.2:
   dependencies:
     pkg-dir "^4.2.0"
     resolve-cwd "^3.0.0"
+
+import-meta-resolve@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/import-meta-resolve/-/import-meta-resolve-1.1.1.tgz#244fd542fd1fae73550d4f8b3cde3bba1d7b2b18"
+  integrity sha512-JiTuIvVyPaUg11eTrNDx5bgQ/yMKMZffc7YSjvQeSMXy58DO2SQ8BtAf3xteZvmzvjYh14wnqNjL8XVeDy2o9A==
+  dependencies:
+    builtins "^4.0.0"
 
 imurmurhash@^0.1.4:
   version "0.1.4"
@@ -11459,7 +11473,7 @@ semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.1.3, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4:
+semver@^7.0.0, semver@^7.1.3, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4:
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1581,6 +1581,13 @@
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
   integrity sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==
 
+"@endo/eslint-plugin@^0.3.10":
+  version "0.3.10"
+  resolved "https://registry.yarnpkg.com/@endo/eslint-plugin/-/eslint-plugin-0.3.10.tgz#e51f4ef8dae474d396b6a98a9ea9bbc983e90c57"
+  integrity sha512-zr0S9NVxY+MiHKmc5m+O5mydm2owfkp15W9JP7EQvZ4qMDlOy30qns0o7dKrk4WGloQHfMqqLdOkCYeKUGKSAQ==
+  dependencies:
+    requireindex "~1.1.0"
+
 "@eslint/eslintrc@^0.4.0":
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.4.0.tgz#99cc0a0584d72f1df38b900fb062ba995f395547"


### PR DESCRIPTION
Refs: #3687

- fix: Add dependencies on jessie and endo eslint plugins
- chore: Update yarn.lock
- fix: Ignore copy of lockdown.umd.js
- refactor: Convert RESM to NESM
- chore: Update yarn.lock
